### PR TITLE
Support Rails 6.1

### DIFF
--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -701,7 +701,7 @@ module StateMachine
       if state && (options[:force] || initialize_state?(object))
         value = state.value
         
-        if hash = options[:to]
+        if hash = options[:to].to_h.deep_dup
           hash[attribute.to_s] = value
         else
           write(object, :state, value)


### PR DESCRIPTION
Make it compatible with Rails 6.1 to get rid of the `FrozenError: can't modify frozen Hash` errors during state initialization.